### PR TITLE
減算処理後に元のオブジェクトとくりぬくオブジェクトを完全に削除するよう修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -494,6 +494,8 @@ async function subtractObjects(fromId, subtractId) {
         
         // Brushオブジェクトを作成
         const fromBrush = new Brush(fromObject.geometry);
+        fromBrush.position.copy(fromObject.position);
+        fromBrush.rotation.copy(fromObject.rotation);
         fromBrush.updateMatrixWorld();
         
         const subtractBrush = new Brush(subtractObject.geometry);
@@ -543,16 +545,25 @@ async function subtractObjects(fromId, subtractId) {
         // 結果のメッシュをシーンに追加
         scene.add(resultMesh);
         
-        // cubes配列を更新
+        // cubes配列を更新 - インデックスの大きい方から先に削除してインデックスのずれを防ぐ
         const fromIndex = cubes.indexOf(fromObject);
         const subtractIndex = cubes.indexOf(subtractObject);
         
-        if (fromIndex !== -1) {
-            cubes.splice(fromIndex, 1);
-        }
-        
-        if (subtractIndex !== -1) {
-            cubes.splice(subtractIndex, 1);
+        // インデックスの大きい方から先に削除
+        if (fromIndex > subtractIndex) {
+            if (fromIndex !== -1) {
+                cubes.splice(fromIndex, 1);
+            }
+            if (subtractIndex !== -1) {
+                cubes.splice(subtractIndex, 1);
+            }
+        } else {
+            if (subtractIndex !== -1) {
+                cubes.splice(subtractIndex, 1);
+            }
+            if (fromIndex !== -1) {
+                cubes.splice(fromIndex, 1);
+            }
         }
         
         // 結果のメッシュにユーザーデータを設定

--- a/script.js
+++ b/script.js
@@ -518,9 +518,27 @@ async function subtractObjects(fromId, subtractId) {
         resultMesh.position.copy(fromObject.position);
         resultMesh.rotation.copy(fromObject.rotation);
         
-        // 元のオブジェクトをシーンから削除
+        // 元のオブジェクトを完全に削除
         scene.remove(fromObject);
+        if (fromObject.geometry) fromObject.geometry.dispose();
+        if (fromObject.material) {
+            if (Array.isArray(fromObject.material)) {
+                fromObject.material.forEach(material => material.dispose());
+            } else {
+                fromObject.material.dispose();
+            }
+        }
+        
+        // くりぬくオブジェクトを完全に削除
         scene.remove(subtractObject);
+        if (subtractObject.geometry) subtractObject.geometry.dispose();
+        if (subtractObject.material) {
+            if (Array.isArray(subtractObject.material)) {
+                subtractObject.material.forEach(material => material.dispose());
+            } else {
+                subtractObject.material.dispose();
+            }
+        }
         
         // 結果のメッシュをシーンに追加
         scene.add(resultMesh);


### PR DESCRIPTION
減算処理をおこなったとき、元のくりぬかれた立体とくりぬいた立体が残ってしまう問題を修正しました。\n\n## 修正内容\n\n- 減算処理後に元のオブジェクト（fromObject）とくりぬくオブジェクト（subtractObject）のジオメトリとマテリアルを適切に破棄するようにしました。\n- これにより、不要なオブジェクトがメモリに残ることを防ぎ、パフォーマンスが向上します。